### PR TITLE
Replace qubell with tonomi

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Install and configure Selenium hub with scalable nodes on docker containers with
 Version 1.0-43p
 -------------
 
-[![Install](https://raw.github.com/qubell-bazaar/component-skeleton/master/img/install.png)](https://express.qubell.com/applications/upload?metadataUrl=https://raw.github.com/qubell-bazaar/component-selenium-mesos/1.0-43p/meta.yml)
+[![Install](https://raw.github.com/qubell-bazaar/component-skeleton/master/img/install.png)](https://express.tonomi.com/applications/upload?metadataUrl=https://raw.github.com/qubell-bazaar/component-selenium-mesos/1.0-43p/meta.yml)
 
 Attributes
 ----------


### PR DESCRIPTION
express.qubell.com -> express.tonomi.com

Risk: Low

Impact: Install link updated to point to correct server

Observable Effect: Install link should work properly
